### PR TITLE
prefer CompletableFuture.thenComposeAsync

### DIFF
--- a/src/main/java/com/datastax/examples/LimitConcurrencyCustomAsync.java
+++ b/src/main/java/com/datastax/examples/LimitConcurrencyCustomAsync.java
@@ -114,7 +114,7 @@ public class LimitConcurrencyCustomAsync {
         // If the lastFeature finishes with failure, the subsequent chained executions
         // will not be invoked. If you wish to alter that behaviour and recover from failure
         // add the exceptionally() call after whenComplete() of lastFeature.
-        lastFeature = lastFeature.thenCompose((ignored) -> executeInsert(session, pst, counter));
+        lastFeature = lastFeature.thenComposeAsync((ignored) -> executeInsert(session, pst, counter));
       }
     }
     return lastFeature;


### PR DESCRIPTION
because `thenCompose` can block the calling thread if the CF already happens to be done.

see https://gist.github.com/XN137/307b8844c5b6d1938a155fad5d7c8757
where `thenApply` is blocking the main thread with id 1 (because the CF is already done) and thus printing before `test 3`