### PR TITLE
modernizing example code for the concurrent requests Java example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Concurrent Requests in Java
-This example shows three different ways of handling concurrent request execution with Apache Cassandra™ using the [Java DataStax Driver](https://docs.datastax.com/en/developer/java-driver/latest).  
+This example shows three different ways of handling concurrent request execution with Apache Cassandra™ using the 
+[Java DataStax Driver](https://docs.datastax.com/en/developer/java-driver/latest).  
 
 
-Contributors: [Olivier Michallat](https://github.com/olim7t), [Hsu-Kwang Hwang](https://github.com/hsuhwang) - derived from [here](https://github.com/datastax/java-driver/tree/4.x/examples/src/main/java/com/datastax/oss/driver/examples/concurrent)
+Contributors: [Olivier Michallat](https://github.com/olim7t), [Hsu-Kwang Hwang](https://github.com/hsuhwang) - derived from 
+[here](https://github.com/datastax/java-driver/tree/4.x/examples/src/main/java/com/datastax/oss/driver/examples/concurrent)
 ## Objectives
 
 * How to limit concurrent query executions with Cassandra in blocking and non-blocking ways. 
@@ -11,16 +13,20 @@ Contributors: [Olivier Michallat](https://github.com/olim7t), [Hsu-Kwang Hwang](
 ## Project Layout
 The following are the main Java files used by the application.
  
-* [LimitConcurrencyCustom](/src/main/java/com/datastax/examples/LimitConcurrencyCustom.java) - This example shows executing concurrent queries in blocking ways. The basic java concurrent mechanism such as SEMAPHORE, and Latch are used to control the flow. 
-* [LimitConcurrencyCustomAsync](/src/main/java/com/datastax/examples/LimitConcurrencyCustomAsync.java) - This example shows executing concurrent queries in non-blocking ways. Java CompletableFuture is used to achieve non-blocking.   
-* [LimitConcurrencyRequestThrottler](/src/main/java/com/datastax/examples/LimitConcurrencyRequestThrottler.java) - Throttling allows you to limit how many requests a session can execute concurrently. This is useful if you have multiple applications connecting to the same Cassandra cluster, and want to enforce some kind of SLA to ensure fair resource allocation.
+* [LimitConcurrencyCustom](/src/main/java/com/datastax/examples/LimitConcurrencyCustom.java) - This example shows executing concurrent queries in blocking ways. 
+The basic java concurrent mechanism such as SEMAPHORE, and Latch are used to control the flow. 
+* [LimitConcurrencyCustomAsync](/src/main/java/com/datastax/examples/LimitConcurrencyCustomAsync.java) - This example shows executing concurrent queries in 
+non-blocking ways. Java CompletableFuture is used to achieve non-blocking.   
+* [LimitConcurrencyRequestThrottler](/src/main/java/com/datastax/examples/LimitConcurrencyRequestThrottler.java) - Throttling allows you to limit how many 
+requests a session can execute concurrently. This is useful if you have multiple applications connecting to the same Cassandra cluster, and want to enforce some 
+kind of SLA to ensure fair resource allocation.
 
 ## Setup and Running
 
 ### Prerequisites
 
 * Maven 3 installed on the machine running the examples 
-* JDK 8 
+* JDK 14
 * An Apache Cassandra(R) cluster is running and accessible through the contacts points and data center identified in [application.conf](/src/main/resources/application.conf)
 
 ### Running
@@ -29,12 +35,12 @@ At the project root level
 
 ```mvn clean package```
 
-This builds the JAR file located at target/java-concurrent-execution-1.0.jar
+This builds the JAR file located at `target/java-concurrent-execution-1.0.jar`
 
 #### Configuration changes
 The main configuration file is `src/main/resources/application.conf`
 Change `basic.contact-points` = ["127.0.0.1:9042"] to the IP and cql port of your Cassandra cluster.
-Change `basic.local-datacenter` = SearchAnalytics to the Cassandra cluster you want to connect to.
+Change `basic.local-datacenter` = dc1 to the datacenter of the Cassandra cluster you want to connect to.
 
 ##### Throttling
 For throttling the configurations are in the following block
@@ -52,6 +58,6 @@ following [link](https://docs.datastax.com/en/developer/java-driver/4.3/manual/c
 
 
 #### Run the program
-* java -cp target/java-concurrent-execution-1.0.jar com.datastax.examples.LimitConcurrencyCustom
-* java -cp target/java-concurrent-execution-1.0.jar com.datastax.examples.LimitConcurrencyCustomAsync 
-* java -cp target/java-concurrent-execution-1.0.jar com.datastax.examples.LimitConcurrencyRequestThrottler
+* `java -cp target/java-concurrent-execution-1.0.jar com.datastax.examples.LimitConcurrencyCustom`
+* `java -cp target/java-concurrent-execution-1.0.jar com.datastax.examples.LimitConcurrencyCustomAsync` 
+* `java -cp target/java-concurrent-execution-1.0.jar com.datastax.examples.LimitConcurrencyRequestThrottler`

--- a/pom.xml
+++ b/pom.xml
@@ -16,63 +16,70 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-  <groupId>com.datastax.oss</groupId>
-  <version>1.0</version>
-  <artifactId>java-concurrent-execution</artifactId>
-  <name>DataStax Concurrent Cassandra Access for Apache Cassandra(R) - examples.</name>
-  <description>A collection of examples to demonstrate Concurrent Execution for Apache
-    Cassandra(R).
-  </description>
+    <groupId>com.datastax.oss</groupId>
+    <version>1.0</version>
+    <artifactId>java-concurrent-execution</artifactId>
 
+    <description>A collection of examples to demonstrate Concurrent Execution for Apache Cassandra(R).</description>
 
-  <properties>
-  <datastax-driver.version>4.3.0</datastax-driver.version>
-  </properties>
-  <dependencies>
+    <properties>
+        <datastax-driver.version>4.3.0</datastax-driver.version>
+    </properties>
 
-    <!-- driver dependencies -->
+    <dependencies>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>java-driver-core</artifactId>
+            <version>${datastax-driver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>java-driver-query-builder</artifactId>
+            <version>${datastax-driver.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
+        </dependency>
+    </dependencies>
 
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>java-driver-core</artifactId>
-      <version>${datastax-driver.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>${project.groupId}</groupId>
-      <artifactId>java-driver-query-builder</artifactId>
-      <version>${datastax-driver.version}</version>
-    </dependency>
-  </dependencies>
-
-  <build>
-    <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
-        <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.1</version>
-        <configuration>
-          <!-- put your configurations here -->
-        </configuration>
-        <executions>
-          <execution>
-            <phase>package</phase>
-            <goals>
-              <goal>shade</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-    </plugins>
-  </build>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>14</source>
+                    <target>14</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <manifest>
+                            <mainClass>com.datastax.examples.LimitConcurrencyCustom</mainClass>
+                        </manifest>
+                    </archive>
+                    <finalName>${artifactId}-${version}</finalName>
+                    <appendAssemblyId>false</appendAssemblyId>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/src/main/java/com/datastax/examples/LimitConcurrencyCustom.java
+++ b/src/main/java/com/datastax/examples/LimitConcurrencyCustom.java
@@ -15,12 +15,10 @@
  */
 package com.datastax.examples;
 
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.insertInto;
-
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.CqlSessionBuilder;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
@@ -29,6 +27,9 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.insertInto;
 
 /**
  * Creates a keyspace and table, and loads data using a multi-threaded approach.
@@ -122,7 +123,7 @@ public class LimitConcurrencyCustom {
 
     System.out.println(
         String.format(
-            "Finished executing %s queries with a concurrency level of %s.",
+            "LimitConcurrencyCustom finished executing %s queries with a concurrency level of %s.",
             insertsCounter.get(), CONCURRENCY_LEVEL));
     // Shutdown executor to free resources
     executor.shutdown();

--- a/src/main/java/com/datastax/examples/LimitConcurrencyCustomAsync.java
+++ b/src/main/java/com/datastax/examples/LimitConcurrencyCustomAsync.java
@@ -15,20 +15,20 @@
  */
 package com.datastax.examples;
 
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.insertInto;
-
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.CqlSessionBuilder;
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiConsumer;
+
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.insertInto;
 
 /**
  * Creates a keyspace and table, and loads data using an async API.
@@ -95,7 +95,7 @@ public class LimitConcurrencyCustomAsync {
 
     System.out.println(
         String.format(
-            "Finished executing %s queries with a concurrency level of %s.",
+            "LimitConcurrencyCustomAsync finished executing %s queries with a concurrency level of %s.",
             INSERTS_COUNTER.get(), CONCURRENCY_LEVEL));
   }
 
@@ -127,7 +127,6 @@ public class LimitConcurrencyCustomAsync {
         .executeAsync(pst.bind().setUuid("id", UUID.randomUUID()).setInt("value", counter))
         .toCompletableFuture()
         .whenComplete(
-            (BiConsumer<AsyncResultSet, Throwable>)
                 (asyncResultSet, throwable) -> {
                   if (throwable == null) {
                     // When the Feature completes and there is no exception - increment counter.

--- a/src/main/java/com/datastax/examples/LimitConcurrencyRequestThrottler.java
+++ b/src/main/java/com/datastax/examples/LimitConcurrencyRequestThrottler.java
@@ -15,17 +15,19 @@
  */
 package com.datastax.examples;
 
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
-import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.insertInto;
-
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.config.DefaultDriverOption;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.internal.core.session.throttling.ConcurrencyLimitingRequestThrottler;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
+import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.insertInto;
 
 /**
  * Creates a keyspace and tables, and loads data using Async API into them.
@@ -96,7 +98,7 @@ public class LimitConcurrencyRequestThrottler {
 
     System.out.println(
         String.format(
-            "Finished executing %s queries with a concurrency level of %s.",
+            "LimitConcurrencyRequestThrottler finished executing %s queries with a concurrency level of %s.",
             pending.size(),
             session
                 .getContext()

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -2,7 +2,7 @@ datastax-java-driver {
   basic.contact-points = ["127.0.0.1:9042"]
   basic {
     load-balancing-policy {
-      local-datacenter = SearchAnalytics
+      local-datacenter = dc1
     }
   }
   # need in LimitConcurrencyRequestThrottler example

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -32,6 +32,6 @@
     <!-- adjust the driver's log verbosity; see
     https://docs.datastax.com/en/developer/java-driver/4.0/manual/core/logging/
     for more information -->
-    <logger name="com.datastax.oss.driver" level="INFO"/>
+    <logger name="com.datastax.oss.driver" level="WARN"/>
 
 </configuration>


### PR DESCRIPTION
DataStax Desktop uses this and two other examples to help users get to know C*/DSE.

I came here to:
* clean up the instructions
* update to latest JDK release (Java 8 is EOL, so we probably shouldn't use it in our examples)
* simplify and make consistent the process of building and running the three examples in question
* quash some irrelevant log output